### PR TITLE
It looks like the footer link for the Chrome Extension has been updated.

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -42,7 +42,11 @@ export default function Footer() {
             <p className="mb-2 text-sm text-muted-foreground">
               Based on EFF Dice-Generated Passphrase methodology for maximum security and memorability.
             </p>
-            <p className="text-sm font-medium text-teal-400">Coming Soon: Chrome Extension</p>
+            <p className="text-sm font-medium text-teal-400">
+              <Link href="https://chromewebstore.google.com/detail/quantumguard-password-gen/dfienhkgfmommaacngnkifnndcbllmlj" target="_blank" rel="noopener noreferrer" className="transition-colors hover:text-primary">
+                Chrome Extension
+              </Link>
+            </p>
           </div>
           <div>
             <h3 className="mb-4 text-lg font-semibold">Support</h3>


### PR DESCRIPTION
The text 'Coming Soon: Chrome Extension' in the footer now directly links to the Chrome Web Store page for the QuantumGuard Password Generator extension.